### PR TITLE
Add page-title and meta-description to trigger vector and vector resp…

### DIFF
--- a/resources/views/trigger-vectors/index.blade.php
+++ b/resources/views/trigger-vectors/index.blade.php
@@ -1,6 +1,13 @@
-@extends('userinterface::layouts.app')
+@php
+    $layout = class_exists(\Iquesters\UserInterface\UserInterfaceServiceProvider::class)
+        ? 'userinterface::layouts.app'
+        : config('dev.layout');
+@endphp
 
-@section('title', 'WooCommerce Integrations')
+@extends($layout)
+
+@section('page-title', \Iquesters\Foundation\Helpers\MetaHelper::make(['Trigger Vector']))
+@section('meta-description', \Iquesters\Foundation\Helpers\MetaHelper::description('Trigger vector sync for WooCommerce integrations'))
 
 @section('content')
 <h5 class="fs-6">WooCommerce Integrations</h5>

--- a/resources/views/trigger-vectors/index.blade.php
+++ b/resources/views/trigger-vectors/index.blade.php
@@ -1,10 +1,4 @@
-@php
-    $layout = class_exists(\Iquesters\UserInterface\UserInterfaceServiceProvider::class)
-        ? 'userinterface::layouts.app'
-        : config('dev.layout');
-@endphp
-
-@extends($layout)
+@extends('userinterface::layouts.app')
 
 @section('page-title', \Iquesters\Foundation\Helpers\MetaHelper::make(['Trigger Vector']))
 @section('meta-description', \Iquesters\Foundation\Helpers\MetaHelper::description('Trigger vector sync for WooCommerce integrations'))

--- a/resources/views/trigger-vectors/index.blade.php
+++ b/resources/views/trigger-vectors/index.blade.php
@@ -2,7 +2,16 @@
 
 @section('page-title', \Iquesters\Foundation\Helpers\MetaHelper::make(['Trigger Vector']))
 @section('meta-description', \Iquesters\Foundation\Helpers\MetaHelper::description('Trigger vector sync for WooCommerce integrations'))
-
+@php
+    $tabs = [
+        [
+            'route' => 'vectors.index',
+            'params' => [],
+            'icon' => 'fa-fw fas fa-satellite-dish',
+            'label' => 'Trigger Vector',
+        ],
+    ];
+@endphp
 @section('content')
 <h5 class="fs-6">WooCommerce Integrations</h5>
 

--- a/resources/views/vector-responses/index.blade.php
+++ b/resources/views/vector-responses/index.blade.php
@@ -2,7 +2,16 @@
 
 @section('page-title', \Iquesters\Foundation\Helpers\MetaHelper::make(['Vector Responses Old']))
 @section('meta-description', \Iquesters\Foundation\Helpers\MetaHelper::description('View old vector responses'))
-
+@php
+    $tabs = [
+        [
+            'route' => 'vectors.responses.index',
+            'params' => [],
+            'icon' => 'fa-fw fas fa-draw-polygon',
+            'label' => 'Vector Responses Old',
+        ],
+    ];
+@endphp
 @section('content')
 <h5 class="fs-6">Vector Responses</h5>
 <div class="table-responsive">

--- a/resources/views/vector-responses/index.blade.php
+++ b/resources/views/vector-responses/index.blade.php
@@ -1,10 +1,4 @@
-@php
-    $layout = class_exists(\Iquesters\UserInterface\UserInterfaceServiceProvider::class)
-        ? 'userinterface::layouts.app'
-        : config('dev.layout');
-@endphp
-
-@extends($layout)
+@extends('userinterface::layouts.app')
 
 @section('page-title', \Iquesters\Foundation\Helpers\MetaHelper::make(['Vector Responses Old']))
 @section('meta-description', \Iquesters\Foundation\Helpers\MetaHelper::description('View old vector responses'))

--- a/resources/views/vector-responses/index.blade.php
+++ b/resources/views/vector-responses/index.blade.php
@@ -1,6 +1,13 @@
-@extends('userinterface::layouts.app')
+@php
+    $layout = class_exists(\Iquesters\UserInterface\UserInterfaceServiceProvider::class)
+        ? 'userinterface::layouts.app'
+        : config('dev.layout');
+@endphp
 
-@section('title', 'Vector Responses')
+@extends($layout)
+
+@section('page-title', \Iquesters\Foundation\Helpers\MetaHelper::make(['Vector Responses Old']))
+@section('meta-description', \Iquesters\Foundation\Helpers\MetaHelper::description('View old vector responses'))
 
 @section('content')
 <h5 class="fs-6">Vector Responses</h5>


### PR DESCRIPTION
##Summary
Added `page-title` and `meta-description` to vector pages in the `iquesters/dev` package to maintain consistency across all packages.

## Changes
- Updated `@extends` to use dynamic layout pattern
- Added `page-title` and `meta-description` to Trigger Vector (`/vector`)
- Added `page-title` and `meta-description` to Vector Responses Old (`/vector/responses`)
 
Closes #2 